### PR TITLE
changed SWC template info to DC and changed setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to Contribute
 
-Software Carpentry is an open source project,
+Data Carpentry is an open source project,
 and we welcome contributions of all kinds:
 new lessons,
 fixes to existing material,
@@ -8,7 +8,7 @@ bug reports,
 and reviews of proposed changes are all equally welcome.
 
 By contributing,
-you are agreeing that Software Carpentry may redistribute your work under
+you are agreeing that Data Carpentry may redistribute your work under
 [these licenses][license].
 You also agree to abide by our
 [contributor code of conduct][conduct].
@@ -24,10 +24,10 @@ You also agree to abide by our
 ## Other Resources
 
 This lesson is based on the template found at
-[https://github.com/swcarpentry/workshop-template][workshop-template].
+[https://github.com/datacarpentry/workshop-template][workshop-template].
 That repository has instructions on formatting and previewing workshop websites.
 
 [conduct]: CONDUCT.md
 [license]: LICENSE.md
 [pro-git-chapter]: http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
-[workshop-template]: https://github.com/swcarpentry/workshop-template
+[workshop-template]: https://github.com/datacarpentry/workshop-template

--- a/FAQ.md
+++ b/FAQ.md
@@ -2,14 +2,14 @@
 
 *   *Where can I get help?*
 
-    Mail us at [admin@software-carpentry.org](mailto:admin@software-carpentry.org),
-    or join our [discussion list](http://lists.software-carpentry.org/mailman/listinfo/discuss_lists.software-carpentry.org)
+    Mail us at [admin@datacarpentry.org](mailto:admin@datacarpentry.org),
+    or go to our [discussion forum](http://discuss.datacarpentry.org)
     and ask for help there.
 
 *   *Where can I report problems or suggest improvements?*
 
-    Please file an issue against [https://github.com/swcarpentry/workshop-template](this repository)
-    or [mail us](mailto:admin@software-carpentry.org).
+    Please file an issue against [https://github.com/datacarpentry/workshop-template](this repository)
+    or [mail us](mailto:admin@datacarpentry.org).
 
 *   *Why does the workshop repository have to be created using `import.github.com`? Why not fork `workshop-template` on GitHub?*
 
@@ -42,7 +42,7 @@
 
 *   *What is the "Windows installer"?*
 
-    We have built a small installation helper for Windows
+    Software Carpentry has built a small installation helper for Windows
     that installs nano and SQLite, adds R to the path, and so on.
     It is maintained in
     [https://github.com/swcarpentry/windows-installer](https://github.com/swcarpentry/windows-installer),
@@ -102,8 +102,8 @@
     The error message may look something like this:
 
     ~~~
-    Configuration file: d:/OpenCourses/swc/2013-10-17-round6.4/_config.yml
-            Source: d:/OpenCourses/swc/2013-10-17-round6.4
+    Configuration file: d:/OpenCourses/dc/2013-10-17-round6.4/_config.yml
+            Source: d:/OpenCourses/dc/2013-10-17-round6.4
        Destination: _site
       Generating... c:/Ruby193/lib/ruby/gems/1.9.1/gems/posix-spawn-0.3.6/lib/posix/spawn.rb:162: wa
     rning: cannot close fd before spawn
@@ -172,7 +172,7 @@
 *   *Help, my website isn't rendering correctly once its pushed to GitHub!*
 
     This can occur if you're trying to view the website over a HTTPS connection
-    because the content from the Software Carpentry website is not currently served over HTTPS.
+    because the content from the Data Carpentry website is not currently served over HTTPS.
     Your browser sees this as unsecure content, so won't load it.
 
     To solve this,

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,7 +5,7 @@ title: Licenses
 ---
 ## Instructional Material
 
-All Software Carpentry instructional material is made available under
+All Data Carpentry instructional material is made available under
 the [Creative Commons Attribution license][cc-by-human]. The following
 is a human-readable summary of (and not a substitute for) the [full
 legal text of the CC BY 4.0 license][cc-by-legal].
@@ -23,9 +23,9 @@ license terms.
 Under the following terms:
 
 * **Attribution**---You must give appropriate credit (mentioning that
-  your work is derived from work that is Copyright © Software
+  your work is derived from work that is Copyright © Data
   Carpentry and, where practical, linking to
-  http://software-carpentry.org/), provide a [link to the
+  http://datacarpentry.org/), provide a [link to the
   license][cc-by-human], and indicate if changes were made. You may do
   so in any reasonable manner, but not in any way that suggests the
   licensor endorses you or your use.
@@ -47,7 +47,7 @@ Notices:
 ## Software
 
 Except where otherwise noted, the example programs and other software
-provided by Software Carpentry are made available under the
+provided by Data Carpentry are made available under the
 [OSI][osi]-approved
 [MIT license][mit-license].
 
@@ -72,8 +72,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## Trademark
 
-"Software Carpentry" and the Software Carpentry logo are registered
-trademarks of [NumFOCUS][numfocus].
+"Data Carpentry" has been submitted for US Trademark.
 
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 =======
 
-This repository is [Software Carpentry](http://software-carpentry.org)'s
+This repository is the [Data Carpentry](http://datacarpentry.org)'s
 template for creating websites for workshops.
 
 1.  Do *not* fork this repository directly on GitHub.
@@ -11,8 +11,8 @@ template for creating websites for workshops.
     since that is what is [automatically published as a website by GitHub](https://help.github.com/articles/creating-project-pages-manually/).
 
 3.  Once you are done,
-    please **send your repository's URL to the [Software Carpentry administrator](mailto:admin@software-carpentry.org)**.
-    We build the [list of workshops on the main website](http://software-carpentry.org/workshops/index.html)
+    please **send your repository's URL to the [Data Carpentry administrator](mailto:admin@datacarpentry.org)**.
+    We build the [list of workshops on the main website](http://datacarpentry.org/workshops/index.html)
     from the data included in your `index.html` page.
     We can only do that if you [customize](CUSTOMIZATION.md) that page correctly
     *and* send us a link to your workshop website.
@@ -41,7 +41,7 @@ template for creating websites for workshops.
 
 4.  Choose a name for your workshop website repository.
     This name should have the form `YYYY-MM-DD-site`,
-    e.g., `2015-07-01-miskatonic`.
+    e.g., `2015-07-01-yale`.
 
 5.  Make sure the repository is public.
 
@@ -76,8 +76,8 @@ since [GitHub automatically publishes that as a website](https://help.github.com
 1.  Go into your newly-created repository,
     which will be at `https://github.com/your_username/YYYY-MM-DD-site`.
     For example,
-    if `your_username` is `gvwilson`,
-    the repository's URL will be `https://github.com/gvwilson/2015-07-01-mistaktonic`.
+    if `your_username` is `gracehopper`, and the site of the workshop is 'yale'
+    the repository's URL will be `https://github.com/gracehopper/2015-07-01-yale`.
 
 2.  Edit `index.html` to customize the list of instructors,
     workshop venue,
@@ -97,8 +97,8 @@ since [GitHub automatically publishes that as a website](https://help.github.com
 
     Note: the URL for your website is determined automatically
     based on the URL for your repository.
-    If your repository is at `https://github.com/gvwilson/2015-07-01-mistaktonic`,
-    its GitHub Pages website is at `http://gvwilson.github.io/2015-07-01-miskatonic`.
+    If your repository is at `https://github.com/gracehopper/2015-07-01-yale`,
+    its GitHub Pages website is at `http://gracehopper.github.io/2015-07-01-yale`.
 
 4.  When you are done editing,
     you can preview your website.

--- a/_config.yml
+++ b/_config.yml
@@ -1,20 +1,19 @@
 #--------------------------------------------------------------------------------
 # Values for this workshop - EDIT THIS SECTION.
 #--------------------------------------------------------------------------------
-workshop_repo   : "http://github.com/swcarpentry/workshop-template"
-workshop_site   : "http://swcarpentry.github.io/workshop-template"
+workshop_repo   : "http://github.com/datacarpentry/workshop-template"
+workshop_site   : "http://datacarpentry.github.io/workshop-template"
 #--------------------------------------------------------------------------------
-# Standard Software Carpentry settings - should not need to be modified.
+# Standard Data Carpentry settings - should not need to be modified.
 #--------------------------------------------------------------------------------
-swc_blog        : "http://software-carpentry.org/feed.xml"
-swc_contact     : "admin@software-carpentry.org"
-swc_files       : "http://files.software-carpentry.org"
-swc_github      : "http://github.com/swcarpentry"
+dc_blog        : "http://datacarpentry.github.io/blog"
+dc_contact     : "admin@datacarpentry.org"
+dc_github      : "http://github.com/datacarpentry"
 swc_installer   : "http://files.software-carpentry.org/SWCarpentryInstaller.exe"
-swc_lessons     : "http://software-carpentry.org/v5/novice"
-swc_site        : "http://software-carpentry.org"
-swc_twitter     : "http://twitter.com/swcarpentry"
-swc_vm          : "https://docs.google.com/uc?id=0B4Kr6DYkzkQtSTZLQzF4aVB4NDQ&export=download"
+#dc_lessons     : "http://software-carpentry.org/v5/novice"
+dc_site        : "http://datacarpentry.org"
+dc_twitter     : "http://twitter.com/datacarpentry"
+#swc_vm          : "https://docs.google.com/uc?id=0B4Kr6DYkzkQtSTZLQzF4aVB4NDQ&export=download"
 #--------------------------------------------------------------------------------
 # Settings for Jekyll - should not need to be modified.
 #--------------------------------------------------------------------------------

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,5 +1,5 @@
 <div class="banner">
-  <a href="http://software-carpentry.org" title="Software Carpentry">
-    <img alt="Software Carpentry banner" src="{{site.swc_site}}/img/software-carpentry-banner.png" />
+  <a href="http://datacarpentry.org" title="Data Carpentry">
+    <img alt="Data Carpentry banner" src="{{site.dc_site}}/images/DC1_logo_small.png" />
   </a>
 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <div class="footer">
   <a class="label swc-blue-bg" href="LICENSE.html">License</a>
-  <a class="label swc-blue-bg" href="{{site.swc_blog}}">Blog</a>
-  <a class="label swc-blue-bg" href="{{site.swc_github}}">GitHub</a>
-  <a class="label swc-blue-bg" href="{{site.swc_twitter}}">Twitter</a>
+  <a class="label swc-blue-bg" href="{{site.dc_blog}}">Blog</a>
+  <a class="label swc-blue-bg" href="{{site.dc_github}}">GitHub</a>
+  <a class="label swc-blue-bg" href="{{site.dc_twitter}}">Twitter</a>
   <a class="label swc-blue-bg" href="{{site.workshop_repo}}/issues/">Issues</a>
 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,8 +1,8 @@
-<link rel="shortcut icon" type="image/x-icon" href="{{site.swc_site}}/v5/favicon.ico" />
+<link rel="shortcut icon" type="image/x-icon" href="{{site.dc_site}}/v5/favicon.ico" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link rel="stylesheet" type="text/css" href="{{page.root}}/css/bootstrap/bootstrap.css"  />
 <link rel="stylesheet" type="text/css" href="{{page.root}}/css/swc.css" />
-<link rel="alternate" type="application/rss+xml" title="The Software Carpentry Blog" href="{{config.site}}/feed.xml"/>
+<link rel="alternate" type="application/rss+xml" title="The Data Carpentry Blog" href="{{config.site}}/feed.xml"/>
 <meta charset="UTF-8" />
 <meta http-equiv="last-modified" content="{{site.timestamp}}" />
 <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->

--- a/_includes/linux.html
+++ b/_includes/linux.html
@@ -1,0 +1,84 @@
+<h3 id="linux">Linux</h3>
+<p>
+Please go through all the installation steps below and make sure that 
+you not only installed them, but start them up to make sure they're working. 
+If you have any problems, don't hesitate to email the instructors to 
+ask for help, or arrive early on the first day of the workshop to 
+get help.
+
+<div class="row-fluid">
+<ol>
+<li><b>A spreadsheet program</b>
+<br>For this workshop you will need a spreadsheet program. Many people already have 
+Microsoft Excel installed, and if you do, you're set! 
+<br>
+If you need a spreadsheet 
+program, there are a few other options, like OpenOffice and LibreOffice. Install 
+instructions for LibreOffice, which is free and open source, are here.
+       <ul>
+          <li><b>Download the Installer</b>
+        <br>Install LibreOffice by going to the <a href=https://www.libreoffice.org/download/libreoffice-fresh/>installation page</a>. The version for Linux 
+should automatically be selected. Click <b>Download Version 4.4.2</b>. You 
+will go to a page that asks about a donation, but you don't need to make one.
+Your download should begin automatically. 
+          <li><b>Install LibreOffice</b>
+            <br>Once the installer is downloaded, double click on it and it should install.
+<li>To use LibreOffice, double click on the icon and it will open.
+</ul>
+
+<p>
+
+<li><b>Google Refine</b>
+<br>Google Refine (previously OpenRefine) is a tool for data cleaning 
+that runs through a web browser, and any browser -
+Safari, Firefox, Chrome, Explorer - should work fine. 
+You will need to download Google Refine and install it, 
+and when you open it, it will run through the browser, but you don't need
+an internet connection, and the data will all be stored on your computer.
+<ul>
+<li>Go to the OpenRefine <a href="http://openrefine.org/download.html">download 
+page</a> 
+<li>Click on <i>Linux kit</i> to download the install file
+<li>Download and extract
+<li>Type ./refine to start and Google Refine will then open in your web browser.
+</ul>
+
+<p>
+
+<li><b>R</b>
+<br>In the workshop, we will use RStudio. RStudio is a nice interface to the 
+programming language R. To use RStudio, you need to install both R and RStudio.
+<ul>
+<li>R is available through most Linux package managers. 
+You can download the binary files for your distribution
+        from <a href="http://cran.r-project.org/index.html">CRAN</a>. Or
+        you can use your package manager (e.g. for Debian/Ubuntu
+        run <code>sudo apt-get install r-base</code> and for Fedora run
+        <code>sudo yum install R</code>). 
+<li>To install RStudi, go to the <a href="http://www.rstudio.com/ide/download/desktop">RStudio Download page</a>
+<li>Under <i>Installers</i> select the version for your distribution.
+<li>Once it's downloaded, double click the file to install it
+<li>Once it's installed, open RStudio to make sure it works and you don't get any error messages.
+</ul>
+
+<p>
+
+<li><b>SQLite</b>
+<br>
+For this workshop we're going to use the Firefox SQLite Plugin. It works through
+the web browser Firefox. 
+<ul>
+<li>If you don't already have Firefox installed 
+<a href="https://www.mozilla.org/en-US/firefox/new/">install Firefox</a>
+<li>Start Firefox      
+<li>Go to the <a href="https://addons.mozilla.org/en-US/firefox/addon/sqlite-manager/">plugin homepage</a>.
+<li> Click the "Add Now" button.
+<li> Click "Install Now" on the dialog that appears after the download completes.
+<li> Restart Firefox when prompted.
+<li> Select "SQLite Manager" from the "Tools" menu and it will open within Firefox
+</ul>
+</ol>
+
+</div>
+
+ 

--- a/_includes/mac.html
+++ b/_includes/mac.html
@@ -1,0 +1,83 @@
+<h3 id="mac">Mac</h3>
+<p>
+Please go through all the installation steps below and make sure that 
+you not only installed them, but start them up to make sure they're working. 
+If you have any problems, don't hesitate to email the instructors to 
+ask for help, or arrive early on the first day of the workshop to 
+get help.
+
+<div class="row-fluid">
+<ol>
+<li><b>A spreadsheet program</b>
+<br>For this workshop you will need a spreadsheet program. Many people already have 
+Microsoft Excel installed, and if you do, you're set! 
+<br>
+If you need a spreadsheet 
+program, there are a few other options, like OpenOffice and LibreOffice. Install 
+instructions for LibreOffice, which is free and open source, are here.
+       <ul>
+          <li><b>Download the Installer</b>
+        <br>Install LibreOffice by going to the <a href=https://www.libreoffice.org/download/libreoffice-fresh/>installation page</a>. The version for Mac 
+should automatically be selected. Click <b>Download Version 4.4.2</b>. You 
+will go to a page that asks about a donation, but you don't need to make one.
+Your download should begin automatically. 
+          <li><b>Install LibreOffice</b>
+            <br>Once the installer is downloaded, double click on it and it should install.
+<li>To use LibreOffice, double click on the icon and it will open.
+</ul>
+
+<p>
+
+<li><b>Google Refine</b>
+<br>Google Refine (previously OpenRefine) is a tool for data cleaning 
+that runs through a web browser, and any browser -
+Safari, Firefox, Chrome, Explorer - should work fine. 
+You will need to download Google Refine and install it, 
+and when you open it, it will run through the browser, but you don't need
+an internet connection, and the data will all be stored on your computer.
+<ul>
+<li>Go to the OpenRefine <a href="http://openrefine.org/download.html">download 
+page</a> 
+<li>Click on <i>Mac kit</i> to download the install file
+<li>Open the downloaded .dmg file
+<li>Drag the icon in to the Applications folder
+<li>Double click on the icon and Google Refine will then open in your web browser.
+</ul>
+
+<p>
+
+<li><b>R</b>
+<br>In the workshop, we will use RStudio. RStudio is a nice interface to the 
+programming language R. To use RStudio, you need to install both R and RStudio.
+<ul>
+<li>Go to <a href=http://cran.r-project.org>CRAN</a> and click on <i>Download
+R for (Mac) OS X</i>
+<li>Select the .pkg file for the version of OS X that you have and the file
+will download.
+<li>Double click on the file that was downloaded and R will install
+<li>Go to the <a href="http://www.rstudio.com/ide/download/desktop">RStudio Download page</a>
+<li>Under <i>Installers</i> select <b>RStudio 0.98.1103 - Mac OS X 10.6+ (64-bit)</b> to download it.
+<li>Once it's downloaded, double click the file to install it
+<li>Once it's installed, open RStudio to make sure it works and you don't get any error messages.
+</ul>
+
+<p>
+
+<li><b>SQLite</b>
+<br>
+For this workshop we're going to use the Firefox SQLite Plugin. It works through
+the web browser Firefox. 
+<ul>
+<li>If you don't already have Firefox installed <a href=https://www.mozilla.org/en-US/firefox/new/>install Firefox</a>
+<li>Start Firefox      
+<li>Go to the <a href="https://addons.mozilla.org/en-US/firefox/addon/sqlite-manager/">plugin homepage</a>.
+<li> Click the "Add Now" button.
+<li> Click "Install Now" on the dialog that appears after the download completes.
+<li> Restart Firefox when prompted.
+<li> Select "SQLite Manager" from the "Tools" menu and it will open within Firefox
+</ul>
+</ol>
+
+</div>
+
+ 

--- a/_includes/windows.html
+++ b/_includes/windows.html
@@ -1,0 +1,82 @@
+<h3 id="windows">Windows</h3>
+<p>
+Please go through all the installation steps below and make sure that 
+you not only installed them, but start them up to make sure they're working. 
+If you have any problems, don't hesitate to email the instructors to 
+ask for help, or arrive early on the first day of the workshop to 
+get help.
+
+<div class="row-fluid">
+<ol>
+<li><b>A spreadsheet program</b>
+<br>For this workshop you will need a spreadsheet program. Many people already have 
+Microsoft Excel installed, and if you do, you're set! 
+<br>
+If you need a spreadsheet 
+program, there are a few other options, like OpenOffice and LibreOffice. Install 
+instructions for LibreOffice, which is free and open source, are here.
+       <ul>
+          <li><b>Download the Installer</b>
+        <br>Install LibreOffice by going to the <a href=https://www.libreoffice.org/download/libreoffice-fresh/>installation page</a>. The version for Windows 
+should automatically be selected. Click <b>Download Version 4.4.2</b>. You 
+will go to a page that asks about a donation, but you don't need to make one.
+Your download should begin automatically. 
+          <li><b>Install LibreOffice</b>
+            <br>Once the installer is downloaded, double click on it and it should install.
+<li>To use LibreOffice, double click on the icon and it will open.
+</ul>
+
+<p>
+
+<li><b>Google Refine</b>
+<br>Google Refine (previously OpenRefine) is a tool for data cleaning 
+that runs through a web browser, and any browser -
+Safari, Firefox, Chrome, Explorer - should work fine. 
+You will need to download Google Refine and install it, 
+and when you open it, it will run through the browser, but you don't need
+an internet connection, and the data will all be stored on your computer.
+<ul>
+<li>Go to the OpenRefine <a href="http://openrefine.org/download.html">download 
+page</a> 
+<li>Click on <i>Windows kit</i> to download the install file
+<li>To use it, unzip, and double-click on google-refine.exe (if you're having issues
+with google-refine.exe try refine.bat instead)
+<li>Google Refine will then open in your web browser.
+</ul>
+
+<p>
+
+<li><b>R</b>
+<br>In the workshop, we will use RStudio. RStudio is a nice interface to the 
+programming language R. To use RStudio, you need to install both R and RStudio.
+<ul>
+<li>      Download R from
+      <a href="http://cran.r-project.org/bin/windows/base/release.htm">here</a>
+<li>Run the .exe file that was just downloaded
+<li>Go to the <a href="http://www.rstudio.com/ide/download/desktop">RStudio Download page</a>
+<li>Under <i>Installers</i> select <b>RStudio 0.98.1103 - Windows XP/Vista/7/8</b>
+<li>Double click the file to install it
+<li>Once it's installed, open RStudio to make sure it works and you don't get any error messages.
+</ul>
+
+<p>
+
+<li><b>SQLite</b>
+<br>
+For this workshop we're going to use the Firefox SQLite Plugin. It works through
+the web browser Firefox. 
+<ul>
+<li>If you don't already have Firefox installed 
+<a href=https://www.mozilla.org/en-US/firefox/new/>install Firefox</a>
+<li>Start Firefox      
+<li>Go to the <a href="https://addons.mozilla.org/en-US/firefox/addon/sqlite-manager/">plugin homepage</a>.
+<li> Click the "Add Now" button.
+<li> Click "Install Now" on the dialog that appears after the download completes.
+<li> Restart Firefox when prompted.
+<li> Select "SQLite Manager" from the "Tools" menu and it will open within Firefox
+</ul>
+</ol>
+
+</div>
+
+ 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,7 +9,7 @@
 -->
 <html>
   <head>
-    <title>Software Carpentry: {{ page.venue }}</title>
+    <title>Data Carpentry: {{ page.venue }}</title>
     {% include header.html %}
   </head>
   <body class="workshop">

--- a/_layouts/setup.html
+++ b/_layouts/setup.html
@@ -1,0 +1,39 @@
+---
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    {% if page.title %}
+      <title>{{ page.title }}</title>
+    {% else %}
+      <title>{{ page.venue }}</title>
+    {% endif %}
+    {% include header.html %}
+    <meta name="venue" content="{{page.venue}}" />
+    <meta name="date" content="{{page.humandate}}" />
+    <meta name="startdate" content="{{page.startdate}}" />
+    <meta name="enddate" content="{{page.enddate}}" />
+  </head>
+  <body>
+    <div class="container">
+      <div class="span10 offset1">
+        {% include banner.html %}
+
+        <div class="hero-unit">
+          <div class="row-fluid">
+            <div class="span10">
+	      <h3>Data Carpentry Workshop Setup Instructions</h3>
+<!--	      <h4>Organized by  </h4> -->
+              <h3>{{page.venue}}</h3>
+	    </div>
+          </div>
+        </div>
+
+        {{content}}
+
+        {% include footer.html %}
+      </div>
+    </div>
+    {% include javascript.html %}
+  </body>
+</html>

--- a/_layouts/workshop.html
+++ b/_layouts/workshop.html
@@ -7,7 +7,7 @@
 -->
 <html>
   <head>
-    <title>Software Carpentry: {{ page.venue }}</title>
+    <title>Data Carpentry: {{ page.venue }}</title>
     {% include header.html %}
     <meta name="venue" content="{{page.venue}}" />
     <meta name="date" content="{{page.humandate}}" />

--- a/_layouts/workshop.html
+++ b/_layouts/workshop.html
@@ -26,7 +26,8 @@
       <div class="jumbotron">
         <div class="row">
           <div class="col-md-10 col-md-offset-1">
-            <h2>{{page.venue}}</h2>
+            <h2>A Data Carpentry Workshop</a>
+	    <h2>{{page.venue}}</h2>
             <div class="row">
               <div class="col-md-6">
                 <p>{{page.humandate}}</p>

--- a/index.html
+++ b/index.html
@@ -55,14 +55,15 @@ day2_pm: "SQL for data management"
   the pitch.
 -->
 <p>
-  <a href="{{site.dc_site}}">Data Carpentry</a>'s mission
-  is to help scientists and engineers get more research done in less
-  time and with less pain by teaching them basic lab skills for
-  scientific computing.  This hands-on workshop will cover basic
-  concepts and tools, including program design, version control, data
-  management, and task automation.  Participants will be encouraged to
-  help one another and to apply what they have learned to their own
-  research problems.
+<a href=http://datacarpentry.org>Data Carpentry</a> workshops are for any researcher 
+who has data they want to analyze, and no prior computational experience is required. 
+This hands-on workshop teaches basic concepts, skills and tools for working more 
+effectively with data. 
+</p>
+<p>
+We will cover {{page.day1_am}}, {{page.day1_pm}}, {{page.day2_am}} and {{page.day2_pm}}.
+
+Participants should bring their laptops and plan to participate actively. By the end of the workshop learners should be able to more effectively manage and analyze data and be able to apply the tools and approaches directly to their ongoing research.
 </p>
 
 <!--

--- a/index.html
+++ b/index.html
@@ -15,6 +15,10 @@ helper: (list of names like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"])
 contact: FIXME (contact email address for workshop organizer)
 etherpad: # FIXME (insert the URL for your Etherpad if you're using one)
 eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 1234567890AB key for Eventbrite registration)
+day1_am: "Data organization in spreadsheets and OpenRefine"
+day1_pm: "Introduction to R"
+day2_am: "Data analysis and visualization in R"
+day2_pm: "SQL for data management"
 ---
 <!--
   HEADER
@@ -51,7 +55,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
   the pitch.
 -->
 <p>
-  <a href="{{site.swc_site}}">Software Carpentry</a>'s mission
+  <a href="{{site.dc_site}}">Data Carpentry</a>'s mission
   is to help scientists and engineers get more research done in less
   time and with less pain by teaching them basic lab skills for
   scientific computing.  This hands-on workshop will cover basic
@@ -59,13 +63,6 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
   management, and task automation.  Participants will be encouraged to
   help one another and to apply what they have learned to their own
   research problems.
-</p>
-<p align="center">
-  <em>
-    For more information on what we teach and why,
-    please see our paper
-    "<a href="http://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1001745">Best Practices for Scientific Computing</a>".
-  </em>
 </p>
 
 <!--
@@ -107,7 +104,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
   <strong>Requirements:</strong> Participants must bring a laptop with
   a few specific software packages installed (listed
   <a href="#setup">below</a>). They are also required to abide by
-  Software Carpentry's
+  Data Carpentry's
   <a href="{{site.swc_site}}/conduct.html">Code of Conduct</a>.
 </p>
 
@@ -138,31 +135,24 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
   to match your plans.  You may also want to change 'Day 1' and 'Day
   2' to be actual dates or days of the week.
 -->
-<h2>Schedule</h2>
+<h2>Preliminary Schedule</h2>
 
 <div class="row">
   <div class="col-md-6">
+
     <h3>Day 1</h3>
     <table class="table table-striped">
-      <tr> <td>09:00</td>  <td>Automating tasks with the Unix shell</td> </tr>
-      <tr> <td>10:30</td> <td>Coffee</td> </tr>
-      <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>13:00</td>  <td>Building programs with Python</td> </tr>
-      <tr> <td>14:30</td>  <td>Coffee</td> </tr>
-      <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>Morning</td>  <td>{{page.day1_am}}</td> </tr>
+       <tr> <td>Afternoon</td>  <td>{{page.day1_pm}}</td> </tr>
     </table>
-  </div>
-  <div class="col-md-6">
+ 
+ 
     <h3>Day 2</h3>
     <table class="table table-striped">
-      <tr> <td>09:00</td>  <td>Version control with Git</td> </tr>
-      <tr> <td>10:30</td>  <td>Coffee</td> </tr>
-      <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>13:00</td>  <td>Managing data with SQL</td> </tr>
-      <tr> <td>14:30</td>  <td>Coffee</td> </tr>
-      <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>Morning</td>  <td>{{page.day2_am}}</td> </tr>
+      <tr> <td>Afternoon</td>  <td>{{page.day2_pm}}</td> </tr>
     </table>
-  </div>
+ </div>
 </div>
 
 <!--
@@ -204,6 +194,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
   please preview your site before committing, and make sure to run
   'tools/check' as well.
 -->
+<!--
 <h2>Syllabus</h2>
 
 <div class="row">
@@ -232,7 +223,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       <li><a href="{{site.swc_lessons}}/ref/03-python.html">Reference...</a></li>
     </ul>
   </div>
-  <!--
+
   <div class="col-md-6">
     <h3>Programming in R</h3>
     <ul>
@@ -244,7 +235,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       <li><a href="{{site.swc_lessons}}/ref/06-R.html">Reference...</a></li>
     </ul>
   </div>
-  -->
+
 </div>
 
 <div class="row">
@@ -278,7 +269,9 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
   </div>
 </div>
 
+
 <hr/>
+-->
 
 <!--
   SETUP
@@ -295,363 +288,17 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 <h2 id="setup">Setup</h2>
 
 <p>
-  To participate in a Software Carpentry workshop, you will need 
-  access to the software described below. In addition, you will 
-  need an up-to-date web browser.
-  Once you are done installing the software listed below,
-  please go to <a href="setup/index.html">this page</a>,
-  which has instructions on how to test that everything was installed correctly.
+To participate in a Data Carpentry workshop, you will need working copies of the 
+described software. Please make sure to install everything (or at least to download 
+the installers) before the start of your workshop. Participants should bring and use 
+their own laptops to insure the proper setup of tools for an efficient workflow 
+once you leave the workshop.
+<p>
+Please follow these <a href=install.html>Setup Instructions</a>
+
+<p>
   We maintain a list of common issues that occur during installation as a reference for instructors
   that may be useful on the
   <a href = "https://github.com/swcarpentry/workshop-template/wiki/Configuration-Problems-and-Solutions">Configuration Problems and Solutions wiki page</a>.
 </p>
 
-<div id="shell"> <!-- Start of 'shell' section. -->
-  <h3>The Bash Shell</h3>
-
-  <p>
-    Bash is a commonly-used shell that gives you the power to do simple
-    tasks more quickly.
-  </p>
-
-  <div class="row">
-    <div class="col-md-4">
-      <h4 id="shell-windows">Windows</h4>
-      <p>
-        Install Git for Windows by downloading and running
-        <a href="http://msysgit.github.io/">the installer</a>.
-        This will provide you with both Git and Bash in the Git Bash program.
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4 id="shell-macosx">Mac OS X</h4>
-      <p>
-        The default shell in all versions of Mac OS X is bash, so no
-        need to install anything.  You access bash from the Terminal
-        (found in
-        <code>/Applications/Utilities</code>).  You may want to keep
-        Terminal in your dock for this workshop.
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4 id="shell-linux">Linux</h4>
-      <p>
-        The default shell is usually Bash, but if your
-        machine is set up differently you can run it by opening a
-        terminal and typing <code>bash</code>.  There is no need to
-        install anything.
-      </p>
-    </div>
-  </div>
-</div> <!-- End of 'shell' section. -->
-
-<div id='git'> <!-- Start of 'Git' section. GitHub browser compatability
-           is given at https://help.github.com/articles/supported-browsers/-->
-  <h3>Git</h3>
-
-  <p>
-    Git is a version control system that lets you track who made changes
-    to what when and has options for easily updating a shared or public
-    version of your code
-    on <a href="https://github.com/">github.com</a>. You will need a
-    <a href="https://help.github.com/articles/supported-browsers/">supported</a>
-    web browser (current versions of Chrome, Firefox or Safari,
-    or Internet Explorer version 9 or above).
-  </p>
-
-  <div class="row">
-    <div class="col-md-4">
-      <h4 id="git-windows">Windows</h4>
-      <p>
-        Git should be installed on your computer as part of your Bash
-        install (described above).
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4 id="git-macosx">Mac OS X</h4>
-      <p>
-        <strong>For OS X 10.8 and higher</strong>, install Git for Mac
-        by downloading and running
-        <a href="http://sourceforge.net/projects/git-osx-installer/files/latest/download">the installer</a>.
-        After installing Git, there will not be anything in your <code>/Applications</code> folder, 
-        as Git is a command line program.
-        <strong>For older versions of OS X (10.5-10.7)</strong> use the
-        most recent available installer for your
-        OS <a href="http://sourceforge.net/projects/git-osx-installer/files/">available here</a>.
-        Use the Leopard installer for 10.5 and the Snow
-        Leopard installer for 10.6-10.7.
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4 id="git-linux">Linux</h4>
-      <p>
-        If Git is not already available on your machine you can try to
-        install it via your distro's package manager. For Debian/Ubuntu run
-        <code>sudo apt-get install git</code> and for Fedora run
-        <code>sudo yum install git</code>.
-      </p>
-    </div>
-  </div>
-</div> <!-- End of 'Git' section. -->
-
-<div id="editor"> <!-- Start of 'editor' section. -->
-  <h3>Text Editor</h3>
-
-  <p>
-    When you're writing code, it's nice to have a text editor that is
-    optimized for writing code, with features like automatic
-    color-coding of key words.  The default text editor on Mac OS X and
-    Linux is usually set to Vim, which is not famous for being
-    intuitive.  if you accidentally find yourself stuck in it, try
-    typing the escape key, followed by <code>:q!</code> (colon, lower-case 'q',
-    exclamation mark), then hitting Return to return to the shell.
-  </p>
-
-  <div class="row">
-    <div class="col-md-4">
-      <h4 id="editor-windows">Windows</h4>
-      <p>
-        nano is a basic editor and the default that instructors use in the workshop.
-        To install it, 
-        download the <a href="{{site.swc_installer}}">Software Carpentry Windows installer</a>
-        and double click on the file to run it.
-        <strong>This installer requires an active internet connection.</strong>
-      </p>
-      <p>
-        Others editors that you can use are
-        <a href="http://notepad-plus-plus.org/">Notepad++</a> or
-        <a href="http://www.sublimetext.com/">Sublime Text</a>.
-        <strong>Be aware that you must
-          add its installation directory to your system path.</strong>
-        Please ask your instructor to help you do this.
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4 id="editor-macosx">Mac OS X</h4>
-      <p>
-        nano is a basic editor and the default that instructors use in the workshop.
-        It should be pre-installed.
-      </p>
-      <p>
-        Others editors that you can use are
-        <a href="http://www.barebones.com/products/textwrangler/">Text Wrangler</a> or
-        <a href="http://www.sublimetext.com/">Sublime Text</a>.
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4 id="editor-linux">Linux</h4>
-      <p>
-        nano is a basic editor and the default that instructors use in the workshop.
-        It should be pre-installed.
-      </p>
-      <p>
-        Others editors that you can use are
-        <a href="https://wiki.gnome.org/Apps/Gedit">Gedit</a>,
-        <a href="http://kate-editor.org/">Kate</a> or
-        <a href="http://www.sublimetext.com/">Sublime Text</a>.
-      </p>
-    </div>
-  </div>
-</div> <!-- End of 'editor' section. -->
-
-<div id="python"> <!-- Start of 'Python' section. Remove the third paragraph if
-           the workshop will teach Python using something other than
-           the IPython notebook.
-           Details at http://ipython.org/ipython-doc/2/install/install.html#browser-compatibility -->
-  <h3>Python</h3>
-
-  <p>
-    <a href="http://python.org">Python</a> is a popular language for
-    scientific computing, and great for general-purpose programming as
-    well.  Installing all of its scientific packages individually can be
-    a bit difficult, so we recommend an all-in-one installer.
-  </p>
-
-    <p>
-      Regardless of how you choose to install it,
-      <strong>please make sure you install Python version 2.x and not version 3.x</strong>
-      (e.g., 2.7 is fine but not 3.4).
-      Python 3 introduced changes that will break some of the code we teach during the workshop.
-    </p>
-
-    <p>
-      We will teach Python using the IPython notebook, a programming environment
-      that runs in a web browser. For this to work you will need a reasonably
-      up-to-date browser. The current versions of the Chrome, Safari and
-      Firefox browsers are all <a 
-      href='http://ipython.org/ipython-doc/2/install/install.html#browser-compatibility'>supported</a> 
-      (some older browsers, including Internet Explorer version 9 
-      and below, are not).
-    </p>
-
-  <div class="row">
-    <div class="col-md-4">
-      <h4 id="python-windows">Windows</h4>
-      <ul>
-        <li>
-          Download and
-          install <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a>.
-        </li>
-        <li>
-          Download the default Python 2 installer (do not follow the link to version 3).
-          Use all of the defaults for installation
-          <em>except</em> make sure to check
-          <strong>Make Anaconda the default Python</strong>.
-        </li>
-      </ul>
-    </div>
-    <div class="col-md-4">
-      <h4 id="python-macosx">Mac OS X</h4>
-      <ul>
-        <li>
-          Download and
-          install <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a>.
-        </li>
-        <li>
-          Download the default Python 2 installer (do not follow the link to version 3).
-          Use all of the defaults for installation.
-        </li>
-      </ul>
-    </div>
-    <div class="col-md-4">
-      <h4 id="python-linux">Linux</h4>
-      <p>
-        We recommend the all-in-one scientific Python installer
-        <a href="http://continuum.io/downloads.html">Anaconda</a>.
-        (Installation requires using the shell and if you aren't
-        comfortable doing the installation yourself just
-        download the installer and we'll help you at the workshop.)
-      </p>
-      <ol>
-        <li>
-          Download the installer that matches your operating
-          system and save it in your home folder.
-          Download the default Python 2 installer (do not follow the link to version 3). 
-        </li>
-        <li>
-          Open a terminal window.
-        </li>
-        <li>
-          Type <pre>bash Anaconda-</pre> and then press
-          tab. The name of the file you just downloaded should
-          appear.
-        </li>
-        <li>
-          Press enter. You will follow the text-only prompts.  When
-          there is a colon at the bottom of the screen press the down
-          arrow to move down through the text. Type <code>yes</code> and
-          press enter to approve the license. Press enter to approve the
-          default location for the files. Type <code>yes</code> and
-          press enter to prepend Anaconda to your <code>PATH</code>
-          (this makes the Anaconda distribution the default Python).
-        </li>
-      </ol>
-    </div>
-  </div>
-</div> <!-- End of 'Python' section. -->
-
-<div id="r"> <!-- Start of 'R' section. -->
-  <h3>R</h3>
-
-  <p>
-    <a href="http://www.r-project.org">R</a> is a programming language
-    that is especially powerful for data exploration, visualization, and
-    statistical analysis. To interact with R, we use
-    <a href="http://www.rstudio.com/">RStudio</a>.
-  </p>
-
-  <div class="row">
-    <div class="col-md-4">
-      <h4 id="r-windows">Windows</h4>
-      <p>
-        Install R by downloading and running
-        <a href="http://cran.r-project.org/bin/windows/base/release.htm">this .exe file</a>
-        from <a href="http://cran.r-project.org/index.html">CRAN</a>.
-        Also, please install the
-        <a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4 id="r-macosx">Mac OS X</h4>
-      <p>
-        Install R by downloading and running
-        <a href="http://cran.r-project.org/bin/macosx/R-latest.pkg">this .pkg file</a>
-        from <a href="http://cran.r-project.org/index.html">CRAN</a>.
-        Also, please install the
-        <a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4 id="r-linux">Linux</h4>
-      <p>
-        You can download the binary files for your distribution
-        from <a href="http://cran.r-project.org/index.html">CRAN</a>. Or
-        you can use your package manager (e.g. for Debian/Ubuntu
-        run <code>sudo apt-get install r-base</code> and for Fedora run
-        <code>sudo yum install R</code>).  Also, please install the
-        <a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
-      </p>
-    </div>
-  </div>
-</div> <!-- End of 'R' section. -->
-
-<div id="sql"> <!-- Start of 'SQLite' section. -->
-  <h3>SQLite</h3>
-
-  <p>
-    SQL is a specialized programming language used with databases.  We
-    use a simple database manager called
-    <a href="http://www.sqlite.org/">SQLite</a> in our lessons.
-  </p>
-
-  <div class="row">
-    <div class="col-md-4">
-      <h4 id="sql-windows">Windows</h4>
-      <p>
-        The <a href="{{site.swc_github}}/windows-installer">Software Carpentry Windows Installer</a>
-        installs SQLite for Windows.
-        If you used the installer to configure nano, you don't need to run it again.
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4 id="sql-macosx">Mac OS X</h4>
-      <p>
-        SQLite comes pre-installed on Mac OS X.
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4 id="sql-linux">Linux</h4>
-      <p>
-        SQLite comes pre-installed on Linux.
-      </p>
-    </div>
-  </div>
-</div> <!-- End of 'SQLite' section. -->
-
-<!--
-  Uncomment this section if you are using our virtual machine.
-
-<div id="vm">
-  <h3>Virtual Machine</h3>
-
-  <p>
-    Some instructors prefer to have learners use a virtual machine (VM)
-    rather than install software on their own computers.  If your
-    instructors have chosen to do this, please:
-  </p>
-  <ol>
-    <li>
-      Install <a href="https://www.virtualbox.org/">VirtualBox</a>.
-    </li>
-    <li>
-      Download our <a href="{{site.swc_vm}}">VM image</a>.
-      <strong>Warning:</strong> this file is 1.7 GByte, so please
-      download it <em>before</em> coming to your workshop.
-    </li>
-    <li>
-      Load the VM into VirtualBox by selecting "Import Appliance" and
-      loading the <code>.ova</code> file.
-    </li>
-  </ol>
-</div>
--->

--- a/install.html
+++ b/install.html
@@ -1,0 +1,58 @@
+---
+layout: setup
+root: .
+assistant: []
+contact: admin@datacarpentry.org
+---
+<!--
+    Edit the values in the parameter block above to be appropriate for your bootcamp.
+    Please use three-letter month names for the 'humandate' field.
+-->
+
+<p>
+  <strong>Requirements:</strong>
+Data Carpentry's teaching is hands-on, so participants are encouraged to bring in and use their own laptops to insure the proper setup of tools for an efficient workflow once you leave the workshop.  (We will provide instructions on setting up the required software several days in advance)
+<em> There are no pre-requisites, and we will assume no prior knowledge about the tools.</em> 
+</p>
+
+
+  <strong>Contact</strong>:
+  Please email
+  {% if page.contact %}
+    <a href='mailto:{{page.contact}}'>{{page.contact}}</a>
+  {% else %}
+    <a href='mailto:{{site.contact}}'>{{site.contact}}</a>
+  {% endif %}
+  for questions and information not covered here.
+</p>
+
+
+
+
+<h2>Setup</h2>
+
+<p>
+  To participate in a Data Carpentry workshop, 
+  you will need working copies of the software described below.
+  Please make sure to install everything and try opening it to make sure it works 
+  <em>before</em> the start of your workshop. If you run into any problems,
+please feel free to email the instructor or arrive early to your workshop on 
+the first day.
+  
+Participants should bring and use their own laptops to insure the proper setup of 
+tools for an efficient workflow once you leave the workshop.
+
+<p>This workshop will be using the software outlined in the install instructions below. 
+Please see the section for your operating system for those directions.
+<ul>
+<li><a href=#windows>Windows</a>
+<li><a href=#mac>Mac</a>
+<li><a href=#linux>Linux</a>
+</ul>  
+
+</p>
+
+{% include windows.html %}
+{% include mac.html %}
+{% include linux.html %}
+


### PR DESCRIPTION
Updated the SWC template to be for Data Carpentry. 
- changed 'software carpentry' to 'data carpentry' and updated links
- changed the schedule information to be preliminary and just 'morning' and 'afternoon'
- changed schedule so that it can be customizable in the YAML
- took out details on schedule since it will be different for different domains and content, so will potentially have to be changed frequently 
- took out detailed setup instructions to put setup info on a different page. Temporarily put this in install.html with info from _includes/windows.html, mac.html and linux.html, but will start an issue on how to best handle setup instructions, since these will also vary per workshop
