### PR TITLE
Rename Google Refine -> OpenRefine, add access tip

### DIFF
--- a/_includes/linux.html
+++ b/_includes/linux.html
@@ -28,8 +28,8 @@ Your download should begin automatically.
 
 <p>
 
-<li><b>Google Refine</b>
-<br>Google Refine (previously OpenRefine) is a tool for data cleaning 
+<li><b>OpenRefine</b>
+<br>OpenRefine (previously Google Refine) is a tool for data cleaning 
 that runs through a web browser, and any browser -
 Safari, Firefox, Chrome, Explorer - should work fine. 
 You will need to download Google Refine and install it, 
@@ -41,6 +41,7 @@ page</a>
 <li>Click on <i>Linux kit</i> to download the install file
 <li>Download and extract
 <li>Type ./refine to start and Google Refine will then open in your web browser.
+<li>If it doesn't open automatically, open a web broswer after you've started the program and go to the URL <code>http://localhost:3333</code> and you should see OpenRefine.
 </ul>
 
 <p>

--- a/_includes/mac.html
+++ b/_includes/mac.html
@@ -28,8 +28,8 @@ Your download should begin automatically.
 
 <p>
 
-<li><b>Google Refine</b>
-<br>Google Refine (previously OpenRefine) is a tool for data cleaning 
+<li><b>OpenRefine</b>
+<br>OpenRefine (previously Google Refine) is a tool for data cleaning 
 that runs through a web browser, and any browser -
 Safari, Firefox, Chrome, Explorer - should work fine. 
 You will need to download Google Refine and install it, 
@@ -42,6 +42,7 @@ page</a>
 <li>Open the downloaded .dmg file
 <li>Drag the icon in to the Applications folder
 <li>Double click on the icon and Google Refine will then open in your web browser.
+<li>If it doesn't open automatically, open a web broswer after you've started the program and go to the URL <code>http://localhost:3333</code> and you should see OpenRefine.
 </ul>
 
 <p>

--- a/_includes/windows.html
+++ b/_includes/windows.html
@@ -28,8 +28,8 @@ Your download should begin automatically.
 
 <p>
 
-<li><b>Google Refine</b>
-<br>Google Refine (previously OpenRefine) is a tool for data cleaning 
+<li><b>OpenRefine</b>
+<br>OpenRefine (previously Google Refine) is a tool for data cleaning 
 that runs through a web browser, and any browser -
 Safari, Firefox, Chrome, Explorer - should work fine. 
 You will need to download Google Refine and install it, 
@@ -42,6 +42,7 @@ page</a>
 <li>To use it, unzip, and double-click on google-refine.exe (if you're having issues
 with google-refine.exe try refine.bat instead)
 <li>Google Refine will then open in your web browser.
+<li>If it doesn't open automatically, open a web broswer after you've started the program and go to the URL <code>http://localhost:3333</code> and you should see OpenRefine.
 </ul>
 
 <p>


### PR DESCRIPTION
The names were switched in the setup instructions, and I added the tip about which URL to go to access OpenRefine in your browser if it doesn't open automatically.
