### PR TITLE
Add optional categories of day1_am, day1_pm, day2_am, and day2_pm

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -338,7 +338,11 @@ HANDLERS = {
     'eventbrite': (False, check_eventbrite, 'Eventbrite key appears invalid.'),
     'etherpad':   (False, check_etherpad, 'Etherpad URL appears invalid.'),
     'venue':      (False, check_pass, 'venue name not specified'),
-    'address':    (False, check_pass, 'address not specified')
+    'address':    (False, check_pass, 'address not specified'),
+    'day1_am':    (False, check_pass, 'day1_am not specified'),
+    'day1_pm':    (False, check_pass, 'day1_pm not specified'),
+    'day2_am':    (False, check_pass, 'day2_am not specified'),
+    'day2_pm':    (False, check_pass, 'day2_pm not specified')
 }
 
 # REQUIRED is all required categories.


### PR DESCRIPTION
Prior to this change, running the check.py helper would list the categories above as superfluous. Since these categories are in the default index.html page, it makes sense to include them as optional rather than listing them as superfluous.

Background: I noticed the superfluous message when working on the webpage for the 2016-02-22 University of Miami workshop. 

TODO: Should I update the version number in check.py to accompany this change? 
