### PR TITLE
updated broken link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ template for creating websites for workshops.
 
 3.  Once you are done,
     please **send your repository's URL to the [Data Carpentry administrator](mailto:admin@datacarpentry.org)**.
-    We build the [list of workshops on the main website](http://datacarpentry.org/workshops/index.html)
+    We build the list of workshops on the main website
     from the data included in your `index.html` page.
     We can only do that if you [customize](CUSTOMIZATION.md) that page correctly
     *and* send us a link to your workshop website.


### PR DESCRIPTION
Took out the link to the list of workshops on our front page, since we're still adding the code to get that to automatically work.
