### PR TITLE
Change country and language instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@ layout: workshop
 root: .
 venue: FIXME (brief name of host site)
 address: FIXME (street address of home location)
-country: FIXME (country (hyphenated if need be, like 'United-Kingdom')
-language: FIXME (language code like 'en' or 'fr')
+country: FIXME (country, hyphenated if need be, like 'United-Kingdom')
+language: FIXME (language code like 'en' or 'fr' - see https://en.wikipedia.org/wiki/ISO_639-1)
 latlng: (fractional latitude and longitude like 41.7901128,-87.6007318)
 humandate: FIXME (use the format 'Feb 17-18, 2020' (without the quotes)
 humantime: FIXME (use the format '9:00 am - 4:30 pm' (without the quotes)


### PR DESCRIPTION
- Remove extra ( from country description
- Add link to ISO_639-1 to description of language code
